### PR TITLE
Add files via upload

### DIFF
--- a/HeatingCtl/hTimer.cpp
+++ b/HeatingCtl/hTimer.cpp
@@ -11,6 +11,10 @@ void hTimer::SetCounter(unsigned long hCount){
 }
     
 bool hTimer::timeup() {return  (millis() - counter > _target);}
+
+bool hTimer::timeup(unsigned long thisTarget) {return (millis() - counter > thisTarget);}
+
+
  
 
 

--- a/HeatingCtl/hTimer.h
+++ b/HeatingCtl/hTimer.h
@@ -14,6 +14,7 @@ class hTimer {
   public:
     void SetCounter(unsigned long hCount);
     bool timeup();
+    bool timeup(unsigned long thisTarget);
   
 };
 


### PR DESCRIPTION
V0.4
Change to allow the 1 minute in 10 cycling to use residual heat from the boiler without firing the boiler.

The boiler will be fired after say 70 seconds - when the demand is more than 1 in 10 cycling.

Timer values moved to #define constants at the start of the project file.